### PR TITLE
Use packed binary data format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 nn
 train
 runs
-parse/target
+target
 convert/target
 libparse.dylib
 libparse.dll

--- a/marlinformat/.gitignore
+++ b/marlinformat/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/marlinformat/Cargo.toml
+++ b/marlinformat/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "marlinformat"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytemuck = { version = "1.10.0", features = ["derive"] }
+cozy-chess = "0.2.2"

--- a/marlinformat/src/lib.rs
+++ b/marlinformat/src/lib.rs
@@ -1,0 +1,170 @@
+#![no_std]
+
+use bytemuck::{Pod, Zeroable};
+use cozy_chess::{BitBoard, Board, BoardBuilder, Color, Piece, Rank, Square};
+
+const UNMOVED_ROOK: u8 = Piece::NUM as u8;
+
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+#[repr(C)]
+pub struct PackedBoard {
+    occupancy: util::U64Le,
+    pieces: util::U4Array32,
+    stm_ep_square: u8,
+    halfmove_clock: u8,
+    fullmove_number: util::U16Le,
+    eval: util::I16Le,
+    wdl: u8,
+    _padding: u8,
+}
+
+impl PackedBoard {
+    pub fn pack(board: &Board, eval: i16, wdl: u8) -> Self {
+        let occupancy = board.occupied();
+
+        let mut pieces = util::U4Array32::default();
+        for (i, sq) in occupancy.into_iter().enumerate() {
+            let piece = board.piece_on(sq).unwrap();
+            let color = board.color_on(sq).unwrap();
+
+            let mut piece_code = piece as u8;
+            if piece == Piece::Rook && sq.rank() == Rank::First.relative_to(color) {
+                let castling_file = match board.king(color) < sq {
+                    true => board.castle_rights(color).short,
+                    false => board.castle_rights(color).long,
+                };
+                if Some(sq.file()) == castling_file {
+                    piece_code = UNMOVED_ROOK;
+                }
+            }
+
+            pieces.set(i, piece_code | (color as u8) << 3);
+        }
+
+        PackedBoard {
+            occupancy: util::U64Le::new(occupancy.0),
+            pieces,
+            stm_ep_square: (board.side_to_move() as u8) << 7
+                | board.en_passant().map_or(Square::NUM as u8, |f| {
+                    Square::new(f, Rank::Sixth.relative_to(board.side_to_move())) as u8
+                }),
+            halfmove_clock: board.halfmove_clock(),
+            fullmove_number: util::U16Le::new(board.fullmove_number()),
+            wdl,
+            eval: util::I16Le::new(eval),
+            _padding: 0,
+        }
+    }
+
+    pub fn unpack(&self) -> Option<(Board, i16, u8)> {
+        let mut builder = BoardBuilder::empty();
+
+        let mut seen_king = [false; 2];
+        for (i, sq) in BitBoard(self.occupancy.get()).into_iter().enumerate() {
+            let color = Color::try_index(self.pieces.get(i) as usize >> 3)?;
+            let piece_code = self.pieces.get(i) & 0b0111;
+            let piece = match piece_code {
+                UNMOVED_ROOK => {
+                    if seen_king[color as usize] {
+                        builder.castle_rights_mut(color).short = Some(sq.file());
+                    } else {
+                        builder.castle_rights_mut(color).long = Some(sq.file());
+                    }
+                    Piece::Rook
+                }
+                _ => Piece::try_index(piece_code as usize)?,
+            };
+            if piece == Piece::King {
+                seen_king[color as usize] = true;
+            }
+            builder.board[sq as usize] = Some((piece, color));
+        }
+
+        builder.en_passant = Square::try_index(self.stm_ep_square as usize & 0b01111111);
+        builder.side_to_move = Color::try_index(self.stm_ep_square as usize >> 7)?;
+        builder.halfmove_clock = self.halfmove_clock;
+        builder.fullmove_number = core::num::NonZeroU16::new(self.fullmove_number.get())?;
+
+        Some((builder.build().ok()?, self.eval.get(), self.wdl))
+    }
+}
+
+mod util {
+    use bytemuck::{Pod, Zeroable};
+
+    #[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+    #[repr(transparent)]
+    pub struct U64Le(u64);
+
+    impl U64Le {
+        pub fn new(v: u64) -> Self {
+            U64Le(v.to_le())
+        }
+
+        pub fn get(self) -> u64 {
+            u64::from_le(self.0)
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+    #[repr(transparent)]
+    pub struct U16Le(u16);
+
+    impl U16Le {
+        pub fn new(v: u16) -> Self {
+            U16Le(v.to_le())
+        }
+
+        pub fn get(self) -> u16 {
+            u16::from_le(self.0)
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+    #[repr(transparent)]
+    pub struct I16Le(i16);
+
+    impl I16Le {
+        pub fn new(v: i16) -> Self {
+            I16Le(v.to_le())
+        }
+
+        pub fn get(self) -> i16 {
+            i16::from_le(self.0)
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, Default, Pod, Zeroable)]
+    #[repr(transparent)]
+    pub struct U4Array32([u8; 16]);
+
+    impl U4Array32 {
+        pub fn get(&self, i: usize) -> u8 {
+            (self.0[i / 2] >> (i % 2) * 4) & 0xF
+        }
+
+        pub fn set(&mut self, i: usize, v: u8) {
+            debug_assert!(v < 0x10);
+            self.0[i / 2] |= v << (i % 2) * 4;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore]
+    fn roundtrip() {
+        // Grab `valid.sfens` from `cozy-chess` to run test
+        for sfen in include_str!("valid.sfens").lines() {
+            let board = Board::from_fen(sfen, true).unwrap();
+            let packed = PackedBoard::pack(&board, 0, 0);
+            let (unpacked, _, _) = packed
+                .unpack()
+                .unwrap_or_else(|| panic!("Failed to unpack {}. {:#X?}", sfen, packed));
+            assert_eq!(board, unpacked, "{}", sfen);
+        }
+    }
+}

--- a/parse/Cargo.lock
+++ b/parse/Cargo.lock
@@ -21,6 +21,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bytemuck"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c53dfa917ec274df8ed3c572698f381a24eef2efba9492d797301b72b6db408a"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +138,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
+name = "marlinformat"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "cozy-chess",
+]
+
+[[package]]
 name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,8 +208,10 @@ dependencies = [
 name = "parse"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "cozy-chess",
  "cozy-syzygy",
+ "marlinformat",
  "rayon",
 ]
 

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -14,3 +14,5 @@ lto = "fat"
 cozy-chess = "0.2.1"
 cozy-syzygy = { git = "https://github.com/MinusKelvin/cozy-syzygy" }
 rayon = "1.5.0"
+marlinformat = { path = "../marlinformat" }
+bytemuck = "1.10.0"

--- a/parse/src/data_loader.rs
+++ b/parse/src/data_loader.rs
@@ -57,7 +57,7 @@ impl FileReader {
         self.packed_buffer
             .par_iter()
             .map(|packed| {
-                let (board, cp, wdl) = packed.unpack()?;
+                let (board, cp, wdl, _) = packed.unpack()?;
                 let cp = cp as f32;
                 let wdl = wdl as f32 / 2.0;
 

--- a/parse/src/data_loader.rs
+++ b/parse/src/data_loader.rs
@@ -1,10 +1,8 @@
-use std::{
-    fs::File,
-    io::{BufRead, BufReader, Lines},
-    path::Path
-};
+use std::{fs::File, io::Read, path::Path};
 
+use bytemuck::Zeroable;
 use cozy_chess::{Board, Color};
+use marlinformat::PackedBoard;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::batch::Batch;
@@ -27,38 +25,46 @@ impl AnnotatedBoard {
 }
 
 pub struct FileReader {
-    file: Lines<BufReader<File>>,
-    string_buffer: Vec<String>,
+    file: File,
+    packed_buffer: Vec<PackedBoard>,
     board_buffer: Vec<Option<AnnotatedBoard>>,
 }
 
 impl FileReader {
     pub fn new(path: impl AsRef<Path>) -> std::io::Result<Self> {
         let file = File::open(path)?;
-        let file = BufReader::new(file).lines();
         Ok(Self {
             file,
-            string_buffer: vec![],
+            packed_buffer: vec![],
             board_buffer: vec![],
         })
     }
 
     fn try_fill_buffer(&mut self, chunk_size: usize) -> bool {
-        self.string_buffer.clear();
-        self.string_buffer.extend((&mut self.file).flat_map(Result::ok).take(chunk_size));
-        self.string_buffer
-            .par_iter()
-            .map(|line| {
-                let (board, annotation) = line.split_once(" | ")?;
-                let (cp, wdl) = annotation.split_once(" | ")?;
+        self.packed_buffer.resize(chunk_size, PackedBoard::zeroed());
+        let buffer = bytemuck::cast_slice_mut(&mut self.packed_buffer);
+        let mut bytes_read = 0;
+        loop {
+            match self.file.read(&mut buffer[bytes_read..]) {
+                Ok(0) => break,
+                Ok(some) => bytes_read += some,
+                Err(_) => break,
+            }
+        }
+        let elems = bytes_read / std::mem::size_of::<PackedBoard>();
+        self.packed_buffer.truncate(elems);
 
-                let cp = cp.parse::<f32>().ok()?;
+        self.packed_buffer
+            .par_iter()
+            .map(|packed| {
+                let (board, cp, wdl) = packed.unpack()?;
+                let cp = cp as f32;
+                let wdl = wdl as f32 / 2.0;
+
                 if cp.abs() > 3000.0 {
                     return None;
                 }
-                let wdl = wdl.parse::<f32>().ok()?;
-                let board = board.parse::<Board>().ok()?;
-                
+
                 Some(AnnotatedBoard { board, cp, wdl })
             })
             .rev()


### PR DESCRIPTION
This PR adds support for a custom packed binary training data format, which I have called `marlinformat`.

On my testing dataset of 10M positions, this reduced the file size by 63% and greatly increased data loading speed.
Single-threaded data loading speed improved from 1.4M FEN/s to 2.6M FEN/s (**91% faster**). Multi-threaded (8T/16C CPU) data loading speed improved from 3.5M FEN/s to 20.1M FEN/s (**467% faster**). I tested this using this code snippet, and ran it several times to ensure the OS had the file cached:
```rs
fn performance_test() {
    let t = std::time::Instant::now();
    let count = FileReader::new("data.bin").unwrap().count();
    panic!("{:.0} FEN/s", count as f64 / t.elapsed().as_secs_f64());
}
```

The basic tool for working with this format is implemented in the new `marlinformat` crate. The format uses 28 bytes to store all of the information required to fully reconstruct a `cozy_chess::Board` (so long as it contains no more than 32 pieces), and so supports FRC and DFRC positionsl. The remaining 4 bytes are used to store eval (as a 16-bit signed integer), game outcome (0/1/2 mean loss/draw/win respectively), and the final byte can be used to store application-specific data.