### PR TITLE
Add interleave, shuffle, and txt-to-data utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +214,10 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 name = "marlinflow-utils"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
+ "cozy-chess",
+ "marlinformat",
+ "rand",
  "serde",
  "serde_json",
  "structopt",
@@ -287,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +347,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -480,6 +531,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -221,6 +239,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "tempfile",
 ]
 
 [[package]]
@@ -404,6 +423,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +528,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,3 +13,4 @@ marlinformat = { path = "../marlinformat" }
 rand = "0.8.5"
 bytemuck = "1.10.0"
 cozy-chess = "0.2.2"
+tempfile = "3.3.0"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2021"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 structopt = "0.3.26"
+marlinformat = { path = "../marlinformat" }
+rand = "0.8.5"
+bytemuck = "1.10.0"
+cozy-chess = "0.2.2"

--- a/utils/src/interleave.rs
+++ b/utils/src/interleave.rs
@@ -1,0 +1,89 @@
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Result, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+use std::time::Instant;
+
+use bytemuck::Zeroable;
+use marlinformat::PackedBoard;
+use rand::distributions::WeightedIndex;
+use rand::{thread_rng, Rng};
+use structopt::StructOpt;
+
+/// Randomly interleave two or more datasets.
+#[derive(StructOpt)]
+pub struct Options {
+    #[structopt(short, long)]
+    output: PathBuf,
+
+    #[structopt(required = true, min_values = 2)]
+    files: Vec<PathBuf>,
+}
+
+pub fn run(options: Options) -> Result<()> {
+    let mut files: Vec<_> = options
+        .files
+        .iter()
+        .map(|path| File::open(path))
+        .collect::<Result<_>>()?;
+
+    let mut into = File::create(options.output)?;
+
+    let start = Instant::now();
+
+    interleave(&mut into, &mut files, |progress, total| {
+        if progress & 0xFFFFF == 0 {
+            let proportion = progress as f64 / total as f64;
+            print!("\r\x1B[K{progress:12}/{total} ({:4.1}%)", proportion * 100.0);
+            let _ = std::io::stdout().flush();
+        }
+    })?;
+    println!();
+    println!("Done ({:.1?}).", start.elapsed());
+
+    Ok(())
+}
+
+pub fn interleave(
+    into: &mut File,
+    files: &mut [File],
+    mut progress: impl FnMut(u64, u64),
+) -> Result<()> {
+    let mut into = BufWriter::new(into);
+    let mut streams = Vec::with_capacity(files.len());
+    let mut total = 0;
+    for file in files {
+        let size_bytes = file.seek(SeekFrom::End(0))?;
+        file.seek(SeekFrom::Start(0))?;
+        let count = size_bytes / std::mem::size_of::<PackedBoard>() as u64;
+        if count > 0 {
+            streams.push((count, BufReader::new(file)));
+            total += count;
+        }
+    }
+
+    let mut sampler = match WeightedIndex::new(streams.iter().map(|&(count, _)| count)) {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+
+    let mut written = 0;
+
+    loop {
+        let index = thread_rng().sample(&sampler);
+        let (count, reader) = &mut streams[index];
+
+        let mut value = PackedBoard::zeroed();
+        reader.read_exact(bytemuck::bytes_of_mut(&mut value))?;
+        into.write_all(bytemuck::bytes_of(&value))?;
+
+        *count -= 1;
+        if *count == 0 {
+            if sampler.update_weights(&[(index, &0)]).is_err() {
+                return Ok(());
+            }
+        }
+
+        written += 1;
+        progress(written, total);
+    }
+}

--- a/utils/src/main.rs
+++ b/utils/src/main.rs
@@ -1,17 +1,20 @@
 use structopt::StructOpt;
 
 mod convert;
+mod interleave;
 mod txt_to_data;
 
 #[derive(StructOpt)]
 pub enum Options {
     Convert(convert::Options),
+    Interleave(interleave::Options),
     TxtToData(txt_to_data::Options),
 }
 
 fn main() {
     match Options::from_args() {
         Options::Convert(options) => convert::run(options),
+        Options::Interleave(options) => interleave::run(options).unwrap(),
         Options::TxtToData(options) => txt_to_data::run(options).unwrap(),
     }
 }

--- a/utils/src/main.rs
+++ b/utils/src/main.rs
@@ -2,11 +2,13 @@ use structopt::StructOpt;
 
 mod convert;
 mod interleave;
+mod shuffle;
 mod txt_to_data;
 
 #[derive(StructOpt)]
 pub enum Options {
     Convert(convert::Options),
+    Shuffle(shuffle::Options),
     Interleave(interleave::Options),
     TxtToData(txt_to_data::Options),
 }
@@ -14,6 +16,7 @@ pub enum Options {
 fn main() {
     match Options::from_args() {
         Options::Convert(options) => convert::run(options),
+        Options::Shuffle(options) => shuffle::run(options).unwrap(),
         Options::Interleave(options) => interleave::run(options).unwrap(),
         Options::TxtToData(options) => txt_to_data::run(options).unwrap(),
     }

--- a/utils/src/main.rs
+++ b/utils/src/main.rs
@@ -1,14 +1,17 @@
 use structopt::StructOpt;
 
 mod convert;
+mod txt_to_data;
 
 #[derive(StructOpt)]
 pub enum Options {
     Convert(convert::Options),
+    TxtToData(txt_to_data::Options),
 }
 
 fn main() {
     match Options::from_args() {
         Options::Convert(options) => convert::run(options),
+        Options::TxtToData(options) => txt_to_data::run(options).unwrap(),
     }
 }

--- a/utils/src/shuffle.rs
+++ b/utils/src/shuffle.rs
@@ -1,0 +1,114 @@
+use std::fs::File;
+use std::io::{Read, Result, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use bytemuck::Zeroable;
+use marlinformat::PackedBoard;
+use rand::prelude::*;
+use structopt::StructOpt;
+
+use crate::interleave::interleave;
+
+#[derive(StructOpt)]
+/// Shuffle a dataset
+pub struct Options {
+    dataset: PathBuf,
+
+    /// Overwrite the input file.
+    #[structopt(long, short)]
+    _in_place: bool,
+
+    /// Output file
+    #[structopt(long, short, required_unless("in-place"))]
+    output: Option<PathBuf>,
+
+    #[structopt(long, default_value = "134217728")]
+    block_size: u64,
+    #[structopt(long, default_value = "256")]
+    group_size: u64,
+}
+
+pub fn run(options: Options) -> Result<()> {
+    let output = options
+        .output
+        .unwrap_or_else(|| options.dataset.clone())
+        .canonicalize()?;
+
+    let mut dataset = File::open(options.dataset)?;
+    let positions = dataset.seek(SeekFrom::End(0))? / std::mem::size_of::<PackedBoard>() as u64;
+    dataset.rewind()?;
+
+    if positions <= options.block_size {
+        println!("in-memory shuffle");
+        let mut data = read(&mut dataset, positions)?;
+        drop(dataset);
+        data.shuffle(&mut thread_rng());
+        let mut target = tempfile::NamedTempFile::new_in(output.parent().unwrap())?;
+        target.write_all(bytemuck::cast_slice(&data))?;
+        target.persist(output)?;
+        return Ok(());
+    }
+
+    let block_count = (positions + options.block_size - 1) / options.block_size;
+
+    let (send, mut recv) = std::sync::mpsc::sync_channel(options.group_size as usize);
+
+    let mut remaining = positions;
+    let mut blocks_shuffled = 0;
+    std::thread::spawn(move || {
+        loop {
+            if remaining == 0 {
+                break;
+            }
+            let count = remaining.min(options.block_size);
+            remaining -= count;
+            let mut data = read(&mut dataset, count).unwrap();
+            data.shuffle(&mut thread_rng());
+            let mut f = tempfile::tempfile().unwrap();
+            f.write_all(bytemuck::cast_slice(&data)).unwrap();
+            send.send(f).unwrap();
+            blocks_shuffled += 1;
+            println!("blocks: {blocks_shuffled}/{block_count}");
+        }
+    });
+
+    let mut items = block_count;
+    let mut level = 0;
+    loop {
+        level += 1;
+        items = (items + options.group_size - 1) / options.group_size;
+        if items == 1 {
+            break;
+        }
+
+        let (nsend, nrecv) = std::sync::mpsc::sync_channel(options.group_size as usize);
+        let mut iter = recv.into_iter();
+        let mut progress = 0;
+        std::thread::spawn(move || loop {
+            let mut files: Vec<_> = (&mut iter).take(options.group_size as usize).collect();
+            if files.is_empty() {
+                break;
+            }
+            let mut to = tempfile::tempfile().unwrap();
+            interleave(&mut to, &mut files, |_, _| {}).unwrap();
+            nsend.send(to).unwrap();
+            progress += 1;
+            println!("lvl. {level}: {progress}/{items}");
+        });
+
+        recv = nrecv;
+    }
+
+    let mut files: Vec<_> = recv.into_iter().collect();
+    let mut target = tempfile::NamedTempFile::new_in(output.parent().unwrap())?;
+    interleave(target.as_file_mut(), &mut files, |_, _| {})?;
+    target.persist(output)?;
+
+    Ok(())
+}
+
+fn read(dataset: &mut File, count: u64) -> Result<Vec<PackedBoard>> {
+    let mut boards = vec![PackedBoard::zeroed(); count as usize];
+    dataset.read_exact(bytemuck::cast_slice_mut(&mut boards))?;
+    Ok(boards)
+}

--- a/utils/src/txt_to_data.rs
+++ b/utils/src/txt_to_data.rs
@@ -1,0 +1,66 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Result, Write};
+use std::path::PathBuf;
+
+use cozy_chess::Board;
+use marlinformat::PackedBoard;
+use structopt::StructOpt;
+
+/// Convert legacy text data format to marlinformat.
+#[derive(StructOpt)]
+pub struct Options {
+    #[structopt(short, long)]
+    output: PathBuf,
+
+    txt_file: PathBuf,
+}
+
+pub fn run(options: Options) -> Result<()> {
+    let input = BufReader::new(File::open(options.txt_file)?);
+    let mut output = BufWriter::new(File::create(options.output)?);
+
+    let mut had_non_integer_cp = false;
+    let mut had_out_of_range_cp = false;
+
+    for line in input.lines() {
+        let line = line?;
+        let _ = (|| {
+            let (board, annotation) = line.split_once(" | ")?;
+            let (cp, wdl) = annotation.split_once(" | ")?;
+
+            let board: Board = board.parse().ok()?;
+            let cp: f32 = cp.parse().ok()?;
+            let wdl: f32 = wdl.parse().ok()?;
+
+            if !had_non_integer_cp && cp.floor() != cp {
+                println!("Warning: dataset contains non-integer centipawn values. These will be truncated.");
+                had_non_integer_cp = true;
+            }
+
+            let cp = match (cp as i64).try_into() {
+                Ok(v) => v,
+                Err(_) => {
+                    if !had_out_of_range_cp {
+                        println!("Warning: dataset contains centipawn values outside the range representable by an i16. These will be saturated.");
+                        had_out_of_range_cp = true;
+                    }
+                    match cp.is_sign_positive() {
+                        true => i16::MAX,
+                        false => i16::MIN,
+                    }
+                },
+            };
+
+            let wdl = match () {
+                _ if wdl < 0.25 => 0,
+                _ if wdl < 0.75 => 1,
+                _ => 2
+            };
+
+            let packed = PackedBoard::pack(&board, cp, wdl, 0);
+            Some(output.write_all(bytemuck::bytes_of(&packed)))
+        })().transpose()?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds basic utilities to convert from the old text data format to marlinformat, randomly interleave marlinformat datasets, and shuffle an existing marlinformat dataset.